### PR TITLE
Add note about deterministic key generation

### DIFF
--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -379,6 +379,22 @@ ARKG-Generate-Seed() -> (pk, sk)
     sk = (sk_kem, sk_bl)
 ~~~
 
+### Deterministic key generation
+
+Although the above definition expresses the key generation as opaque,
+likely sampling random key distributions,
+implementations MAY choose to implement the functions `BL-Generate-Keypair()`,
+`KEM-Generate-Keypair()` and `ARKG-Generate-Seed()`
+as deriving keys deterministically from some given input key material.
+This can be thought of as defining a single-use ARKG instance where these functions return a constant result.
+This use case is beyond the scope of this document
+since the implementation of `ARKG-Generate-Seed` is internal to the delegating party,
+even if applications choose to distribute the delegating party across multiple processing entities.
+
+For example, one entity may randomly sample `pk_bl`, derive `pk_kem` deterministically from `pk_bl`
+and submit only `pk_bl` to a separate service that uses the same procedure to also derive the same `pk_kem`.
+This document considers both of these entities as parts of the same logical delegating party.
+
 
 ## The function ARKG-Derive-Public-Key
 

--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -382,11 +382,11 @@ ARKG-Generate-Seed() -> (pk, sk)
 ### Deterministic key generation
 
 Although the above definition expresses the key generation as opaque,
-likely sampling random key distributions,
+likely sampling uniformly random key distributions,
 implementations MAY choose to implement the functions `BL-Generate-Keypair()`,
 `KEM-Generate-Keypair()` and `ARKG-Generate-Seed()`
-as deriving keys deterministically from some given input key material.
-This can be thought of as defining a single-use ARKG instance where these functions return a constant result.
+as deterministic functions of some out-of-band input.
+This can be thought of as defining a single-use ARKG instance where these function outputs are static.
 This use case is beyond the scope of this document
 since the implementation of `ARKG-Generate-Seed` is internal to the delegating party,
 even if applications choose to distribute the delegating party across multiple processing entities.


### PR DESCRIPTION
(2024-04-03) Review comments from @AltmannPeter and @sander: There are desired use cases for deterministically generated seed keys, such as that outlined in the example here.

I don't think the defined procedures really need to change, since this is rather an implementation detail for the delegating party. I think we can just note that implementations are free to make that choice, without defining an interoperability API for this.

(A formal definition of `ARKG-Generate-Seed` is needed just to tie `BL-Generate-Keypair` and `KEM-Generate-Keypair` together, but its implementation details are not important for interoperability, unlike `ARKG-Derive-Public-Key` and `ARKG-Derive-Secret-Key`.)