### PR TITLE
Use seed term instead of key in ARKG-Generate-Seed output description

### DIFF
--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -376,8 +376,8 @@ ARKG-Generate-Seed() -> (pk, sk)
     Inputs: None
 
     Output:
-        (pk, sk)  An ARKG seed key pair with public key pk
-                    and private key sk.
+        (pk, sk)  An ARKG seed pair with public seed pk
+                    and private seed sk.
 
     The output (pk, sk) is calculated as follows:
 


### PR DESCRIPTION
To help highlight that the ARKG seed pair doesn't necessarily need to consist directly of keys for other algorithms, it can be anything that is valid inputs to ARKG-Derive-Public-Key and ARKG-Derive-Secret-Key.