### PR TITLE
Sign over the key handle, not info_sub, in HMAC-adapted KEM

### DIFF
--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -587,7 +587,7 @@ KEM-Encaps(pk, info) -> (k, c)
         PRK: prk
         info: 'ARKG-KEM-HMAC-mac.' || DST_ext || info
         L: L
-    t = HMAC-Hash-128(K=mk, text=info_sub)
+    t = HMAC-Hash-128(K=mk, text=c')
 
     k = HKDF-Expand with the arguments:
         Hash: Hash
@@ -615,7 +615,7 @@ KEM-Decaps(sk, c, info) -> k
         info: 'ARKG-KEM-HMAC-mac.' || DST_ext || info
         L: L
 
-    t' = HMAC-Hash-128(K=mk, text=info_sub)
+    t' = HMAC-Hash-128(K=mk, text=c')
     If t = t':
         k = HKDF-Expand with the arguments:
             Hash: Hash


### PR DESCRIPTION
Discovered while testing a prototype implementation - the MAC is computed over the domain separation tags, not the KEM ciphertext. Not sure what I was thinking when I initially wrote that in 52b738efda6f0cf2dee2f4aa797cb899f6be38b7 - the initial commit 139af55600ed4101e704ffc147bdd777037c5e62 has the MAC sign over both the ciphertext and the DST.

The DSTs are still mixed into the MAC since they are part of the derivation of the MAC key.