### PR TITLE
Update reference to published Paper; modified citation style

### DIFF
--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -87,7 +87,7 @@ informative:
     author:
     - name: Pieter Wuille
     date: 2012
-  AC:BCF24:
+  AC:BreCleFis24:
     target: https://eprint.iacr.org/2023/1275
     author:
     - name: Jacqueline Brendel
@@ -114,7 +114,7 @@ informative:
     title: "Asynchronous Remote Key Generation: An Analysis of Yubico's Proposal for W3C WebAuthn. CCS '20: Proceedings of the 2020 ACM SIGSAC Conference on Computer and Communications Security"
     date: 2020
     target: https://eprint.iacr.org/2020/1004
-  Frymann2023:
+  EUROSP:FryGarMan23:
     author:
     - name: Nick Frymann
     - name: Daniel Gardham
@@ -1236,7 +1236,7 @@ Frymann et al. [CCS:FGKLMN20] generalized the constructions by Lundberg, Nilsson
 from elliptic curves to any discrete logarithm (DL) problem,
 and also proved the security of arbitrary asymmetric protocols composed with ARKG.
 Further generalizations to include quantum-resistant instantiations
-were developed independently by Brendel et al. [AC:BCF24], Frymann et al. [Frymann2023] and Wilson [Wilson].
+were developed independently by Brendel et al. [AC:BreCleFis24], Frymann et al. [FryGarMan23] and Wilson [Wilson].
 
 This document adopts the construction proposed by Wilson [Wilson],
 modified by the inclusion of a MAC in the key handles as done in the original construction by Frymann et al. [CCS:FGKLMN20].

--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -87,13 +87,15 @@ informative:
     author:
     - name: Pieter Wuille
     date: 2012
-  Clermont:
-    target: https://www.cryptoplexity.informatik.tu-darmstadt.de/media/crypt/teaching_1/theses_1/Sebastian_Clermont_Thesis.pdf
+  AC:BCF24:
+    target: https://eprint.iacr.org/2023/1275
     author:
-    - name: Sebastian A. Clermont
+    - name: Jacqueline Brendel
+    - name: Sebastian Clermont
+    - name: Marc Fischlin
       org: "Technische Universität Darmstadt"
-    date: 2022
-    title: "Post Quantum Asynchronous Remote Key Generation. Master's thesis"
+    date: 2023
+    title: "Post-Quantum Asynchronous Remote Key Generation for FIDO2 Account Recovery. ASIACRYPT '24"
   WebAuthn-Recovery:
     author:
     - name: Emil Lundberg
@@ -101,7 +103,7 @@ informative:
     title: "WebAuthn recovery extension: Asynchronous delegated key generation without shared secrets. GitHub"
     date: 2019
     target: https://github.com/Yubico/webauthn-recovery-extension
-  Frymann2020:
+  CCS:FGKLMN20:
     author:
     - name: Nick Frymann
     - name: Daniel Gardham
@@ -478,7 +480,7 @@ which can be used to define concrete ARKG instantiations.
 ## Using elliptic curve addition for key blinding {#blinding-ec}
 
 Instantiations of ARKG whose output keys are elliptic curve keys
-can use elliptic curve addition as the key blinding scheme `BL` [Frymann2020]&nbsp;[Wilson].
+can use elliptic curve addition as the key blinding scheme `BL` [CCS:FGKLMN20]&nbsp;[Wilson].
 This section defines a general formula for such instantiations of `BL`.
 
 This formula has the following parameters:
@@ -629,7 +631,7 @@ KEM-Decaps(sk, c, info) -> k
 
 ## Using ECDH as the KEM {#kem-ecdh}
 
-Instantiations of ARKG can use ECDH [RFC6090] as the key encapsulation mechanism `KEM` [Frymann2020]&nbsp;[Wilson].
+Instantiations of ARKG can use ECDH [RFC6090] as the key encapsulation mechanism `KEM` [CCS:FGKLMN20]&nbsp;[Wilson].
 This section defines a general formula for such instantiations of `KEM`.
 
 This formula has the following parameters:
@@ -728,7 +730,7 @@ The `KEM` parameter of ARKG may be instantiated as described in section {{hmac-k
 
 When an ARKG instance uses the same type of key for both the key blinding and the KEM -
 for example, if elliptic curve arithmetic is used for key blinding as described in {{blinding-ec}}
-and ECDH is used as the KEM as described in {{kem-ecdh}} [Frymann2020] -
+and ECDH is used as the KEM as described in {{kem-ecdh}} [CCS:FGKLMN20] -
 then the two keys MAY be the same key.
 Representations of such an ARKG seed MAY allow for omitting the second copy of the constituent key,
 but such representations MUST clearly identify that the single constituent key is to be used
@@ -1188,7 +1190,7 @@ This section registers the following values in the IANA "COSE Algorithms" regist
 
 The ARKG construction by Wilson [Wilson] omits the MAC and instead encodes application context in the PRF labels,
 arguing that this leads to invalid keys/signatures in cases that would have a bad MAC.
-We choose to keep the MAC from the construction by Frymann et al. [Frymann2020],
+We choose to keep the MAC from the construction by Frymann et al. [CCS:FGKLMN20],
 but allow it to be omitted in case the chosen KEM already guarantees ciphertext integrity.
 
 The reason for this is to ensure that the delegating party can distinguish key handles that belong to its ARKG seed.
@@ -1208,12 +1210,12 @@ For this reason, we require the KEM to guarantee ciphertext integrity
 so that `ARKG-Derive-Private-Key` can fail early if the key handle belongs to a different ARKG seed.
 
 It is straightforward to see that adding the MAC to the construction by Wilson
-does not weaken the security properties defined by Frymann et al. [Frymann2020]:
+does not weaken the security properties defined by Frymann et al. [CCS:FGKLMN20]:
 the construction by Frymann et al. can be reduced to the ARKG construction in this document
 by instantiating `BL` as described in {{blinding-ec}}
 and `KEM` as described in {{kem-ecdh}}.
-The use of hash_to_field in {{blinding-ec}} corresponds to the KDF<sub>1</sub> parameter in [Frymann2020],
-and the use of HMAC and HKDF in {{hmac-kem}} corresponds to the MAC and KDF<sub>2</sub> parameters in [Frymann2020].
+The use of hash_to_field in {{blinding-ec}} corresponds to the KDF<sub>1</sub> parameter in [CCS:FGKLMN20],
+and the use of HMAC and HKDF in {{hmac-kem}} corresponds to the MAC and KDF<sub>2</sub> parameters in [CCS:FGKLMN20].
 Hence if one can break PK-unlinkability or SK-security of the ARKG construction in this document,
 one can also break the same property of the construction by Frymann et al.
 
@@ -1227,17 +1229,17 @@ TODO
 
 # Acknowledgements
 
-ARKG was first proposed under this name by Frymann et al. [Frymann2020],
+ARKG was first proposed under this name by Frymann et al. [CCS:FGKLMN20],
 who analyzed a proposed extension to W3C Web Authentication by Lundberg and Nilsson [WebAuthn-Recovery],
 which was in turn inspired by a similar construction by Wuille [BIP32] used to create privacy-preserving Bitcoin addresses.
-Frymann et al. [Frymann2020] generalized the constructions by Lundberg, Nilsson and Wuille
+Frymann et al. [CCS:FGKLMN20] generalized the constructions by Lundberg, Nilsson and Wuille
 from elliptic curves to any discrete logarithm (DL) problem,
 and also proved the security of arbitrary asymmetric protocols composed with ARKG.
 Further generalizations to include quantum-resistant instantiations
-were developed independently by Clermont [Clermont], Frymann et al. [Frymann2023] and Wilson [Wilson].
+were developed independently by Brendel et al. [AC:BCF24], Frymann et al. [Frymann2023] and Wilson [Wilson].
 
 This document adopts the construction proposed by Wilson [Wilson],
-modified by the inclusion of a MAC in the key handles as done in the original construction by Frymann et al. [Frymann2020].
+modified by the inclusion of a MAC in the key handles as done in the original construction by Frymann et al. [CCS:FGKLMN20].
 
 The authors would like to thank all of these authors for their research and development work that led to the creation of this document.
 


### PR DESCRIPTION
The Master Thesis by Clermont has since been published at Asiacrypt2024. The references have been updated to point to the conference version and to acknowledge the co-authors.

Furthermore, the citation style of [Clermont] and [Frymann2020] has been updated to match the convention used by Cryptobib to allow for an easy identification of the venue where it was published and the authors involved in the project.