### PR TITLE
Compute tau' in the same way as signature-key-blinding

### DIFF
--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -502,8 +502,8 @@ BL-Generate-Keypair() -> (pk, sk)
 
 BL-Blind-Public-Key(pk, tau, info) -> pk_tau
 
-    tau' = hash_to_field(tau, 1) with the parameters:
-        DST: 'ARKG-BL-EC.' || DST_ext || info
+    tau' = hash_to_field(tau || 0x00 || info, 1) with the parameters:
+        DST: 'ARKG-BL-EC.' || DST_ext
         F: GF(N), the scalar field
            of the prime order subgroup of crv
         p: N
@@ -517,8 +517,8 @@ BL-Blind-Public-Key(pk, tau, info) -> pk_tau
 
 BL-Blind-Private-Key(sk, tau, info) -> sk_tau
 
-    tau' = hash_to_field(tau, 1) with the parameters:
-        DST: 'ARKG-BL-EC.' || DST_ext || info
+    tau' = hash_to_field(tau || 0x00 || info, 1) with the parameters:
+        DST: 'ARKG-BL-EC.' || DST_ext
         F: GF(N), the scalar field
            of the prime order subgroup of crv.
         p: N


### PR DESCRIPTION
This change increases interoperability with [draft-irtf-cfrg-signature-key-blinding-07](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-signature-key-blinding-07). In that draft, the message for `hash_to_field` is `tau || 0x00 || info`, and the `DST` is a static string such as `"ECDSA Key Blind"`.

See for the interoperability issue [draft-dijkhuis-cfrg-hdkeys-05](https://datatracker.ietf.org/doc/html/draft-dijkhuis-cfrg-hdkeys-05): § 3.2. After this fix, `DeriveBlindingFactor` in HDK is compatible with the computation of `tau'` in the ARKG key blinding functions.