### PR TITLE
Move COSE_Key_Ref and two-party alg definitions to separate spec

### DIFF
--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -46,6 +46,7 @@ contributor:
 
 normative:
   I-D.jose-fully-spec-algs: I-D.draft-ietf-jose-fully-specified-algorithms
+  I-D.lundberg-cose-2p-algs: I-D.draft-lundberg-cose-two-party-signing-algs
   IANA.cose:
   RFC2104:
   RFC4949:
@@ -919,8 +920,8 @@ The identifier `ARKG-edwards448ADD-X448` represents the following ARKG instance:
 # COSE bindings {#cose}
 
 This section proposes additions to COSE [RFC9052] to support ARKG use cases.
-The novelty lies primarily in a new key type definition to represent ARKG public seeds
-and new key type definitions to represent references to private keys rather than the keys themselves.
+These consist of new key type definitions to represent ARKG public seeds
+and references [I-D.lundberg-cose-2p-algs] to private keys derived using ARKG.
 
 
 ## COSE key type: ARKG public seed {#cose-arkg-pub-seed}
@@ -976,26 +977,23 @@ h'a5013a0001000002582060b6dfddd31659598ae5de49acb220d8704949e84d48
 ~~~
 
 
-## COSE key reference types {#cose-key-refs}
+## References to ARKG derived private keys {#cose-arkg-derived-refs}
 
-TODO: This should eventually move to a separate "algoritm IDs for two-party signing" spec, see: [](https://mailarchive.ietf.org/arch/msg/cose/BjIO9qDNbuVinxAph7F-Z88GpFY/)
+A reference to a private key derived using ARKG
+may be represented as a `COSE_Key_Ref` structure [I-D.lundberg-cose-2p-algs]
+whose `kty` is `TBD (placeholder -65538)`.
+This represents the arguments to use in `ARKG-Derive-Private-Key` to acquire the referenced private key:
+the `kid` parameter identifies the ARKG private seed `sk`
+and the `kh` and `info` parameters contain the arguments for the respective parameter of `ARKG-Derive-Private-Key`.
 
-While keys used by many other algorithms can usually be referenced by a single atomic identifier,
-such as that used in the `kid` parameter in a COSE_Key object or in the unprotected header of a COSE_Recipient,
-users of the function `ARKG-Derive-Secret-Key` need to represent
-a reference to an ARKG private seed along with a key handle for a derived private key.
+A `COSE_Key_Ref` structure whose `kty` is `TBD (placeholder -65538)`
+MUST include the parameters `kh (-1)` and `info (-2)` defined in {{tbl-ref-arkg-params}}.
 
-A COSE key reference is a COSE_Key object whose `kty` value is defined to represent a reference to a key.
-The `kid` parameter MUST be present when `kty` is a key reference type.
-These requirements are encoded in the CDDL [RFC8610] type `COSE_Key_Ref`:
-
-~~~cddl
-COSE_Key_Ref = COSE_Key .within {
-  1 ^ => $COSE_kty_ref   ; kty: Any reference type
-  2 ^ => any,            ; kid is required
-  any => any,            ; Any other entries allowed by COSE_Key
-}
-~~~
+{: #tbl-ref-arkg-params title="COSE_Key_Ref parameters for the Ref-ARKG-derived type."}
+| Name | COSE Value | Description |
+| ---- | ---------- | ----------- |
+| kh   | -1         | `kh` argument to `ARKG-Derive-Private-Key` |
+| info | -2         | `info` argument to `ARKG-Derive-Private-Key` |
 
 The following CDDL example represents a reference to a key derived by `ARKG-P256ADD-ECDH`
 and restricted for use with the ESP256 [I-D.jose-fully-spec-algs] signature algorithm:
@@ -1059,26 +1057,12 @@ This section registers the following values in the IANA "COSE Key Types" registr
   - Value: TBD (Placeholder -65538)
   - Description: Reference to private key derived by ARKG
   - Capabilities: \[kty(-65538), kh\]
-  - Reference: {{cose-key-refs}} of this document
+  - Reference: {{cose-arkg-derived-refs}} of this document
 
-- Name: Ref-OKP
-  - Value: TBD (Requested assignment -1)
-  - Description: Reference to a key pair of key type "OKP"
-  - Capabilities: \[kty(-1), crv\]
-  - Reference: {{cose-key-refs}} of this document
-
-- Name: Ref-EC2
-  - Value: TBD (Requested assignment -2)
-  - Description: Reference to a key pair of key type "EC2"
-  - Capabilities: \[kty(-1), crv\]
-  - Reference: {{cose-key-refs}} of this document
-
-These registrations add the following choices to the CDDL [RFC8610] type socket `$COSE_kty_ref`:
+These registrations add the following choices to the CDDL [RFC8610] type socket `$COSE_kty_ref` [I-D.lundberg-cose-2p-algs]:
 
 ~~~cddl
 $COSE_kty_ref /= -65538   ; Placeholder value
-$COSE_kty_ref /= -1       ; Value TBD
-$COSE_kty_ref /= -2       ; Value TBD
 ~~~
 
 
@@ -1107,14 +1091,14 @@ This section registers the following values in the IANA "COSE Key Type Parameter
   - Label: -1
   - CBOR Type: bstr
   - Description: kh argument to ARKG-Derive-Private-Key
-  - Reference: {{cose-key-refs}} of this document
+  - Reference: {{cose-arkg-derived-refs}} of this document
 
 - Key Type: TBD (Ref-ARKG-derived, placeholder -65538)
   - Name: info
   - Label: -2
   - CBOR Type: bstr
   - Description: info argument to ARKG-Derive-Private-Key
-  - Reference: {{cose-key-refs}} of this document
+  - Reference: {{cose-arkg-derived-refs}} of this document
 
 
 ## COSE Algorithms Registrations

--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -45,17 +45,7 @@ contributor:
   country: SE
 
 normative:
-  fully-spec-algs:
-    title: Fully-Specified Algorithms for JOSE and COSE
-    target: https://datatracker.ietf.org/doc/draft-ietf-jose-fully-specified-algorithms/
-    author:
-    - name: Michael B. Jones
-      ins: M.B. Jones
-      org: Self-Issued Consulting
-      email: michael_b_jones@hotmail.com
-      uri: https://self-issued.info
-    date: 2024
-  IANA.cose:
+  I-D.jose-fully-spec-algs: I-D.draft-ietf-jose-fully-specified-algorithms
   IANA.cose:
   RFC2104:
   RFC4949:
@@ -943,7 +933,7 @@ The `alg` parameter, when present,
 defines the `alg` parameter of ARKG derived public keys derived from this ARKG public seed.
 
 The following CDDL [RFC8610] example represents an `ARKG-P256ADD-ECDH` public seed
-restricted to generating derived public keys for use with the ESP256 [fully-spec-algs] signature algorithm:
+restricted to generating derived public keys for use with the ESP256 [I-D.jose-fully-spec-algs] signature algorithm:
 
 ~~~cddl
 {
@@ -1008,7 +998,7 @@ COSE_Key_Ref = COSE_Key .within {
 ~~~
 
 The following CDDL example represents a reference to a key derived by `ARKG-P256ADD-ECDH`
-and restricted for use with the ESP256 [fully-spec-algs] signature algorithm:
+and restricted for use with the ESP256 [I-D.jose-fully-spec-algs] signature algorithm:
 
 ~~~cddl
 {
@@ -1138,7 +1128,7 @@ This section registers the following values in the IANA "COSE Algorithms" regist
   - Description: ESP256 with key derived by ARKG-P256ADD-ECDH
   - Capabilities: \[kty\]
   - Change Controller: TBD
-  - Reference: [fully-spec-algs], {{ARKG-P256ADD-ECDH}} of this document
+  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-P256ADD-ECDH}} of this document
   - Recommended: Yes
 
 - Name: ESP384-ARKG
@@ -1146,7 +1136,7 @@ This section registers the following values in the IANA "COSE Algorithms" regist
   - Description: ESP384 with key derived by ARKG-P384ADD-ECDH
   - Capabilities: \[kty\]
   - Change Controller: TBD
-  - Reference: [fully-spec-algs], {{ARKG-P384ADD-ECDH}} of this document
+  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-P384ADD-ECDH}} of this document
   - Recommended: Yes
 
 - Name: ESP512-ARKG
@@ -1154,7 +1144,7 @@ This section registers the following values in the IANA "COSE Algorithms" regist
   - Description: ESP512 with key derived by ARKG-P521ADD-ECDH
   - Capabilities: \[kty\]
   - Change Controller: TBD
-  - Reference: [fully-spec-algs], {{ARKG-P521ADD-ECDH}} of this document
+  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-P521ADD-ECDH}} of this document
   - Recommended: Yes
 
 - Name: ES256K-ARKG
@@ -1170,7 +1160,7 @@ This section registers the following values in the IANA "COSE Algorithms" regist
   - Description: Ed25519 with key derived by ARKG-edwards25519ADD-X25519
   - Capabilities: \[kty\]
   - Change Controller: TBD
-  - Reference: [fully-spec-algs], {{ARKG-edwards25519ADD-X25519}} of this document
+  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-edwards25519ADD-X25519}} of this document
   - Recommended: Yes
 
 - Name: Ed448-ARKG
@@ -1178,7 +1168,7 @@ This section registers the following values in the IANA "COSE Algorithms" regist
   - Description: Ed448 with key derived by ARKG-edwards448ADD-X448
   - Capabilities: \[kty\]
   - Change Controller: TBD
-  - Reference: [fully-spec-algs], {{ARKG-edwards448ADD-X448}} of this document
+  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-edwards448ADD-X448}} of this document
   - Recommended: Yes
 
 

--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -1058,7 +1058,7 @@ This section registers the following values in the IANA "COSE Key Types" registr
 - Name: Ref-ARKG-derived
   - Value: TBD (Placeholder -65538)
   - Description: Reference to private key derived by ARKG
-  - Capabilities: \[kty(-65538), kh\]
+  - Capabilities: \[kty(-65538), kh, info\]
   - Reference: [I-D.lundberg-cose-2p-algs], {{cose-arkg-derived-refs}} of this document
 
 These registrations add the following choices to the CDDL [RFC8610] type socket `$COSE_kty_ref` [I-D.lundberg-cose-2p-algs]:

--- a/draft-bradleylundberg-cfrg-arkg.md
+++ b/draft-bradleylundberg-cfrg-arkg.md
@@ -981,13 +981,15 @@ h'a5013a0001000002582060b6dfddd31659598ae5de49acb220d8704949e84d48
 
 A reference to a private key derived using ARKG
 may be represented as a `COSE_Key_Ref` structure [I-D.lundberg-cose-2p-algs]
-whose `kty` is `TBD (placeholder -65538)`.
-This represents the arguments to use in `ARKG-Derive-Private-Key` to acquire the referenced private key:
-the `kid` parameter identifies the ARKG private seed `sk`
-and the `kh` and `info` parameters contain the arguments for the respective parameter of `ARKG-Derive-Private-Key`.
+whose `kty` is `TBD` (Ref-ARKG-derived, placeholder -65538).
+This key reference type defines key type parameters -1 and -2 respectively
+for the `kh` and `info` parameters of `ARKG-Derive-Private-Key`.
+The `kid` (2) parameter identifies the ARKG private seed `sk`.
+Thus the `COSE_Key_Ref` structure conveys all arguments to use in `ARKG-Derive-Private-Key`
+to acquire the referenced private key.
 
-A `COSE_Key_Ref` structure whose `kty` is `TBD (placeholder -65538)`
-MUST include the parameters `kh (-1)` and `info (-2)` defined in {{tbl-ref-arkg-params}}.
+A `COSE_Key_Ref` structure whose `kty` is TBD (Ref-ARKG-derived, placeholder -65538)
+MUST include the parameters `kh` (-1) and `info` (-2) defined in {{tbl-ref-arkg-params}}.
 
 {: #tbl-ref-arkg-params title="COSE_Key_Ref parameters for the Ref-ARKG-derived type."}
 | Name | COSE Value | Description |
@@ -1057,7 +1059,7 @@ This section registers the following values in the IANA "COSE Key Types" registr
   - Value: TBD (Placeholder -65538)
   - Description: Reference to private key derived by ARKG
   - Capabilities: \[kty(-65538), kh\]
-  - Reference: {{cose-arkg-derived-refs}} of this document
+  - Reference: [I-D.lundberg-cose-2p-algs], {{cose-arkg-derived-refs}} of this document
 
 These registrations add the following choices to the CDDL [RFC8610] type socket `$COSE_kty_ref` [I-D.lundberg-cose-2p-algs]:
 
@@ -1067,8 +1069,6 @@ $COSE_kty_ref /= -65538   ; Placeholder value
 
 
 ## COSE Key Type Parameters Registrations
-
-TODO: These should eventually move to a separate "algoritm IDs for two-party signing" spec, see: [](https://mailarchive.ietf.org/arch/msg/cose/BjIO9qDNbuVinxAph7F-Z88GpFY/)
 
 This section registers the following values in the IANA "COSE Key Type Parameters" registry [IANA.COSE].
 
@@ -1091,69 +1091,14 @@ This section registers the following values in the IANA "COSE Key Type Parameter
   - Label: -1
   - CBOR Type: bstr
   - Description: kh argument to ARKG-Derive-Private-Key
-  - Reference: {{cose-arkg-derived-refs}} of this document
+  - Reference: [I-D.lundberg-cose-2p-algs], {{cose-arkg-derived-refs}} of this document
 
 - Key Type: TBD (Ref-ARKG-derived, placeholder -65538)
   - Name: info
   - Label: -2
   - CBOR Type: bstr
   - Description: info argument to ARKG-Derive-Private-Key
-  - Reference: {{cose-arkg-derived-refs}} of this document
-
-
-## COSE Algorithms Registrations
-
-TODO: These should eventually move to a separate "algoritm IDs for two-party signing" spec, see: [](https://mailarchive.ietf.org/arch/msg/cose/BjIO9qDNbuVinxAph7F-Z88GpFY/)
-
-This section registers the following values in the IANA "COSE Algorithms" registry [IANA.COSE].
-
-- Name: ESP256-ARKG
-  - Value: TBD (Placeholder -65539)
-  - Description: ESP256 with key derived by ARKG-P256ADD-ECDH
-  - Capabilities: \[kty\]
-  - Change Controller: TBD
-  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-P256ADD-ECDH}} of this document
-  - Recommended: Yes
-
-- Name: ESP384-ARKG
-  - Value: TBD (Placeholder -65540)
-  - Description: ESP384 with key derived by ARKG-P384ADD-ECDH
-  - Capabilities: \[kty\]
-  - Change Controller: TBD
-  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-P384ADD-ECDH}} of this document
-  - Recommended: Yes
-
-- Name: ESP512-ARKG
-  - Value: TBD (Placeholder -65541)
-  - Description: ESP512 with key derived by ARKG-P521ADD-ECDH
-  - Capabilities: \[kty\]
-  - Change Controller: TBD
-  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-P521ADD-ECDH}} of this document
-  - Recommended: Yes
-
-- Name: ES256K-ARKG
-  - Value: TBD (Placeholder -65542)
-  - Description: ES256K with key derived by ARKG-P256kADD-ECDH
-  - Capabilities: \[kty\]
-  - Change Controller: TBD
-  - Reference: [RFC8812], {{ARKG-P256kADD-ECDH}} of this document
-  - Recommended: Yes
-
-- Name: Ed25519-ARKG
-  - Value: TBD (Placeholder -65543)
-  - Description: Ed25519 with key derived by ARKG-edwards25519ADD-X25519
-  - Capabilities: \[kty\]
-  - Change Controller: TBD
-  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-edwards25519ADD-X25519}} of this document
-  - Recommended: Yes
-
-- Name: Ed448-ARKG
-  - Value: TBD (Placeholder -65544)
-  - Description: Ed448 with key derived by ARKG-edwards448ADD-X448
-  - Capabilities: \[kty\]
-  - Change Controller: TBD
-  - Reference: [I-D.jose-fully-spec-algs], {{ARKG-edwards448ADD-X448}} of this document
-  - Recommended: Yes
+  - Reference: [I-D.lundberg-cose-2p-algs], {{cose-arkg-derived-refs}} of this document
 
 
 # Design rationale


### PR DESCRIPTION
These are moved to: https://github.com/YubicoLabs/cose-two-party-signing-algs-rfc

I chose to keep the definitions of the ARKG-pub and Ref-ARKG-derived types in this document since they are intrinsically linked to ARKG and do not depend on the two-party signing alg IDs. The algorithm registrations, however, do belong better in the other spec since they are specifically about defining how to generate a signature and are entirely irrelevant to signature verifiers.

I also want to change the definition of the `alg` parameter in the ARKG-pub type, as the current definition is unconventional and confusing:

>The alg parameter, when present, defines the alg parameter of ARKG derived public keys derived from this ARKG public seed.

Rather I think `alg` (3), if present, should represent the ARKG instance of the public seed (for which we currently define no alg IDs, so it cannot be used), and the usage of derived keys should instead be represented by a new parameter if at all. But I'll leave that for a separate PR.